### PR TITLE
Bumped jruby to 1.7.13

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ vertxVersion=2.1RC3
 testFrameworkVersion=2.0.0-final
 toolsVersion=2.0.3-final
 junitVersion=4.10
-jrubyVersion=1.7.11
+jrubyVersion=1.7.13


### PR DESCRIPTION
JRuby 1.7.13 contains lots of improvements compared to 1.7.11, including this very important one: https://github.com/jruby/jruby/pull/1546

FYI we notice a solid 25% speed gain when bootstraping our JRuby Vert.x applications when we manually replace JRuby with version 1.7.13 in the fat-jar we run.
