### PR TITLE
fix monkey patch Kernal#load arity

### DIFF
--- a/src/main/api_shim/core/vertx_require.rb
+++ b/src/main/api_shim/core/vertx_require.rb
@@ -7,17 +7,17 @@ module Kernel
   alias_method :original_require, :require
   alias_method :original_load, :load
 
-  def require name
+  def require(*args)
     org.vertx.java.platform.impl.JRubyVerticleFactory.requireCallback do
       #puts "in require callback"
-      original_require name
+      original_require(*args)
     end
   end
 
-  def load name
+  def load(*args)
     org.vertx.java.platform.impl.JRubyVerticleFactory.requireCallback do
       #puts "in require callback"
-      original_load name
+      original_load(*args)
     end
   end
 


### PR DESCRIPTION
The original method has a variable arity of 1..2, see:
http://www.ruby-doc.org/core-2.1.2/Kernel.html#method-i-load
