### PR TITLE
Use ruby 2.0 compatibility mode

### DIFF
--- a/src/main/java/org/vertx/java/platform/impl/JRubyVerticleFactory.java
+++ b/src/main/java/org/vertx/java/platform/impl/JRubyVerticleFactory.java
@@ -59,7 +59,7 @@ public class JRubyVerticleFactory implements VerticleFactory {
     try {
       Thread.currentThread().setContextClassLoader(cl);
       this.scontainer = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
-      scontainer.setCompatVersion(CompatVersion.RUBY1_9);
+      scontainer.setCompatVersion(CompatVersion.RUBY2_0);
       //Prevent JRuby from logging errors to stderr - we want to log ourselves
       scontainer.setErrorWriter(new NullWriter());
     } finally {


### PR DESCRIPTION
I'm working on a project with keyword args, and I've been unable to find any other way to push JRuby to launch into 2.0 compatibility mode other than this.
