### PR TITLE
Enable set verify host

### DIFF
--- a/src/main/api_shim/core/http.rb
+++ b/src/main/api_shim/core/http.rb
@@ -227,13 +227,13 @@ module Vertx
     end
 
     # Get or set verify host
-    def verify_host(val = nil)
-      if val
-        @j_del.setVerifyHost(val)
-        self
-      else
-        @j_del.isVerifyHost
-      end
+    def verify_host
+      @j_del.isVerifyHost
+    end
+
+    def verify_host(val)
+      @j_del.setVerifyHost(val)
+      self
     end
 
     # Gets the max WebSocket Frame size in bytes

--- a/src/main/java/org/vertx/java/platform/impl/JRubyVerticleFactory.java
+++ b/src/main/java/org/vertx/java/platform/impl/JRubyVerticleFactory.java
@@ -59,7 +59,7 @@ public class JRubyVerticleFactory implements VerticleFactory {
     try {
       Thread.currentThread().setContextClassLoader(cl);
       this.scontainer = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
-      scontainer.setCompatVersion(CompatVersion.RUBY2_0);
+      scontainer.setCompatVersion(CompatVersion.RUBY1_9);
       //Prevent JRuby from logging errors to stderr - we want to log ourselves
       scontainer.setErrorWriter(new NullWriter());
     } finally {

--- a/src/main/java/org/vertx/java/platform/impl/JRubyVerticleFactory.java
+++ b/src/main/java/org/vertx/java/platform/impl/JRubyVerticleFactory.java
@@ -59,7 +59,7 @@ public class JRubyVerticleFactory implements VerticleFactory {
     try {
       Thread.currentThread().setContextClassLoader(cl);
       this.scontainer = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
-      scontainer.setCompatVersion(CompatVersion.RUBY1_9);
+      scontainer.setCompatVersion(CompatVersion.RUBY2_0);
       //Prevent JRuby from logging errors to stderr - we want to log ourselves
       scontainer.setErrorWriter(new NullWriter());
     } finally {


### PR DESCRIPTION
It is currently impossible to set the `verify_host` value to false on an `HttpClient`, because if you pass in an argument of false, then the "falsey" branch executes, and it just returns the current value. 

I separated the getter and setter, so now this is reachable.
